### PR TITLE
add ELECTION_CREATORS to settings.py

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -214,7 +214,7 @@ AUTH_DEFAULT_AUTH_SYSTEM = get_from_env('AUTH_DEFAULT_AUTH_SYSTEM', None)
 
 # who can create an election?
 # (parameter specific to openSUSE auth)
-ELECTION_CREATORS = []
+ELECTION_CREATORS = ['foobar']
 
 # google
 GOOGLE_CLIENT_ID = get_from_env('GOOGLE_CLIENT_ID', '')

--- a/settings.py
+++ b/settings.py
@@ -212,6 +212,10 @@ HELIOS_PRIVATE_DEFAULT = False
 AUTH_ENABLED_AUTH_SYSTEMS = get_from_env('AUTH_ENABLED_AUTH_SYSTEMS', 'google').split(",")
 AUTH_DEFAULT_AUTH_SYSTEM = get_from_env('AUTH_DEFAULT_AUTH_SYSTEM', None)
 
+# who can create an election?
+# (parameter specific to openSUSE auth)
+ELECTION_CREATORS = []
+
 # google
 GOOGLE_CLIENT_ID = get_from_env('GOOGLE_CLIENT_ID', '')
 GOOGLE_CLIENT_SECRET = get_from_env('GOOGLE_CLIENT_SECRET', '')


### PR DESCRIPTION
This is needed to fix a test failure 

    AttributeError: 'Settings' object has no attribute 'ELECTION_CREATORS'

The tests also expect that user `foobar` is allowed to create an election, therefore add this user to ELECTION_CREATORS in settings.py.